### PR TITLE
Delegate cerificate hostname verification to OpenSSL

### DIFF
--- a/scripts/run-unittests.sh
+++ b/scripts/run-unittests.sh
@@ -17,26 +17,30 @@ run-test () {
 
 test-hostname-verification() {
     test/tlscommunicationtest.py test test pass
-    test/tlscommunicationtest.py test '*' pass
-    test/tlscommunicationtest.py test 'te*' pass
-    test/tlscommunicationtest.py testsite 'te*site' pass
-    test/tlscommunicationtest.py testsite 't*s*e' fail
+    test/tlscommunicationtest.py test '*' fail
+    test/tlscommunicationtest.py test 'te*' fail
+    test/tlscommunicationtest.py test '*st' fail
+    test/tlscommunicationtest.py test 'test*' fail
+    test/tlscommunicationtest.py test '*test' fail
+    test/tlscommunicationtest.py test 't*st' fail
+    test/tlscommunicationtest.py test 'te*st' fail
+    test/tlscommunicationtest.py test 't*s*' fail
     test/tlscommunicationtest.py test.sub test.sub pass
     test/tlscommunicationtest.py test.sub '*.sub' pass
     test/tlscommunicationtest.py test.sub '*' fail
-    test/tlscommunicationtest.py test.sub '*.*' pass
+    test/tlscommunicationtest.py test.sub '*.*' fail
+    test/tlscommunicationtest.py test.sub 'te*.sub' pass
+    test/tlscommunicationtest.py test.sub '*st.sub' pass
+    test/tlscommunicationtest.py test.sub 'test*.sub' pass
+    test/tlscommunicationtest.py test.sub '*test.sub' pass
+    test/tlscommunicationtest.py test.sub 't*st.sub' fail
+    test/tlscommunicationtest.py test.sub 'te*st.sub' fail
+    test/tlscommunicationtest.py test.sub 't*s*.sub' fail
     test/tlscommunicationtest.py test.sub invalid.sub fail
     test/tlscommunicationtest.py test.sub 'invalid.*' fail
     test/tlscommunicationtest.py TEST.SUB test.sub pass
-    test/tlscommunicationtest.py test '*ss' fail
-    test/tlscommunicationtest.py test 'tt*' fail
-    test/tlscommunicationtest.py test 'test*' pass
-    test/tlscommunicationtest.py test '*test' pass
-    test/tlscommunicationtest.py test '*te' fail
-    test/tlscommunicationtest.py test 'te*st' pass
     test/tlscommunicationtest.py test tes fail
     test/tlscommunicationtest.py test testa fail
-    test/tlscommunicationtest.py teest 'tee*est' fail
 }
 
 test-client-system-bundle() {


### PR DESCRIPTION
The OpenSSL verification is stricter than our current ad-hoc one. As a
result, wildcard matching is no longer performed for

- hostnames with less than three labels

  https://github.com/openssl/openssl/blob/5f5edd7d3eb20c39177b9fa6422f1db57634e9e3/crypto/x509/v3_utl.c#L746

- hostnames where the first label is of the form X*Y

  https://github.com/openssl/openssl/blob/5f5edd7d3eb20c39177b9fa6422f1db57634e9e3/crypto/x509/v3_utl.c#L720