### PR TITLE
Implement CA bundle sharing (reference counting)

### DIFF
--- a/include/tls_connection.h
+++ b/include/tls_connection.h
@@ -68,16 +68,17 @@ tls_conn_t *open_tls_client(async_t *async,
 
 /* While each call to open_tls_client() constructs a separate CA bundle,
  * open_tls_client_2() allows for sharing one CA bundle among several
- * connections, which should be better for performance. The bundle
- * should exist for as long as the TLS connection exists. */
+ * connections, which should be better for performance. The CA bundle
+ * is only needed for the duration of the call. */
 tls_conn_t *open_tls_client_2(async_t *async,
                               bytestream_1 encrypted_input_stream,
                               tls_ca_bundle_t *ca_bundle,
                               const char *server_hostname);
 
-/* Make asynctls take control over tls context, created elsewhere.
- * WARNING: This function is very implementation specific, so you must ensure
- * that underlying implementation of asynctls matches the one you are using. */
+/* Make asynctls take control over the tls context, created elsewhere.
+ * WARNING: This function is very implementation-specific, so you must
+ * ensure that the underlying implementation of asynctls matches the
+ * one you are using. */
 tls_conn_t *adopt_tls_client(async_t *async,
                              bytestream_1 encrypted_input_stream,
                              tls_ca_bundle_t *ca_bundle,
@@ -110,6 +111,16 @@ tls_ca_bundle_t *make_pinned_tls_ca_bundle(const char *pem_file_pathname,
                                            const char *pem_dir_pathname);
 
 void destroy_tls_ca_bundle(tls_ca_bundle_t *ca_bundle);
+
+/* Create a new reference to an already existing CA bundle. The
+ * shared, underlying data structures are protected through reference
+ * counting. Each tls_ca_bundle_t object must be deallocated
+ * eventually using destroy_tls_ca_bundle().
+ *
+ * The return value may be the same as or different from ca_bundle. If
+ * the same reference is returned, destroy_tls_ca_bundle() must be
+ * called twice for the same reference. */
+tls_ca_bundle_t *share_tls_ca_bundle(tls_ca_bundle_t *ca_bundle);
 
 tls_conn_t *open_tls_server(async_t *async,
                             bytestream_1 encrypted_input_stream,

--- a/include/tls_connection.h
+++ b/include/tls_connection.h
@@ -170,8 +170,8 @@ const char *tls_get_server_name(tls_conn_t *conn);
 
 /* This function is used by the client to inform the server (through
  * the ALPN extension) about the acceptability of one or more
- * protocols. Call the function separately for each protocol. If the
- * function is not called, no ALPN exchange will take place.
+ * protocols. If the function is not called, no ALPN exchange will
+ * take place.
  *
  * Terminate the protocol list with (const char *) NULL.
  *

--- a/include/tls_underlying.h
+++ b/include/tls_underlying.h
@@ -25,7 +25,6 @@ struct tls_conn {
     bool is_client;
     union {
         struct {
-            bool ca_bundle_shared;
             tls_ca_bundle_t *ca_bundle;
             char *alpn_choice;
         } client;

--- a/scripts/run-unittests.sh
+++ b/scripts/run-unittests.sh
@@ -40,8 +40,12 @@ test-fstrace() {
 }
 
 realpath () {
-    # reimplementation of "readlink -fw" for OSX
-    python -c "import os.path, sys; print os.path.realpath(sys.argv[1])" "$1"
+    if [ -x "/bin/realpath" ]; then
+        /bin/realpath "$@"
+    else
+        python -c "import os.path, sys; print os.path.realpath(sys.argv[1])" \
+               "$1"
+    fi
 }
 
 main() {

--- a/src/tls_securetransport.c
+++ b/src/tls_securetransport.c
@@ -316,6 +316,11 @@ void destroy_tls_ca_bundle(tls_ca_bundle_t *ca_bundle)
 {
 }
 
+tls_ca_bundle_t *share_tls_ca_bundle(tls_ca_bundle_t *ca_bundle)
+{
+    return ca_bundle;
+}
+
 static bool read_file(const char *path, CFMutableDataRef data)
 {
     int fd = open(path, O_RDONLY);


### PR DESCRIPTION
Previously, difficulties were created for the client application to maintain the lifetime of the CA bundle. Adding reference counting to the CA bundle removes those difficulties without causing backward-incompatility.