### PR TITLE
Fix build on macOS Catalina

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -28,7 +28,7 @@ TARGET_DEFINES = {
 TARGET_FLAGS = {
     'linux32': '-m32 ',
     'linux64': '',
-    'darwin': ''
+    'darwin': '-mmacosx-version-min=10.13 '
 }
 
 def libconfig_builder(env):


### PR DESCRIPTION
The Secure Transport framework is deprecated in the macOS Catalina SDK
and generates '-Wdeprecated-declarations' warnings which cause the
build to fail because of '-Werror'. This commit fixes the build by
setting the minimum target and SDK to macOS 10.13. Switching to the
OpenSSL backend seems to be the only feasible long-term solution,
since the new Network framework provides only a higher-level API.