### PR TITLE
Simplify fstracecheck test

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -26,7 +26,7 @@ def target_architectures():
 TARGET_DEFINES = {
     'freebsd_amd64': [],
     'linux32': ['_FILE_OFFSET_BITS=64'],
-    'linux64': [],
+    'linux64': ['_FILE_OFFSET_BITS=64'],
     'openbsd_amd64': [],
     'darwin': []
 }

--- a/fstracecheck.in
+++ b/fstracecheck.in
@@ -3,7 +3,6 @@
 flags=(
     --cc=@CC@
     -Iinclude
-    -D_FILE_OFFSET_BITS=64
 )
 
 case $(uname -s) in
@@ -13,8 +12,4 @@ case $(uname -s) in
         ;;
 esac
 
-libconfig_flags=$(@CONFIG_PARSER@ |
-    tr ' ' '\n' |
-    grep '^-[DI]')
-
-exec @FSTRACECHECK@ "${flags[@]}" $libconfig_flags @SOURCES@
+exec @FSTRACECHECK@ @CPPFLAGS@ "${flags[@]}" @SOURCES@

--- a/test/SConscript
+++ b/test/SConscript
@@ -28,7 +28,7 @@ env.Substfile('fstracecheck.in',
               '#fstracecheck.in',
               SUBST_DICT = {
                   '@CC@': '$CC',
-                  '@CONFIG_PARSER@': '$CONFIG_PARSER',
+                  '@CPPFLAGS@':  '$_CPPDEFFLAGS' + '$_CPPINCFLAGS',
                   '@FSTRACECHECK@': '$FSTRACECHECK',
                   '@SOURCES@': ' '.join(sources),
               }


### PR DESCRIPTION
By using the C preprocessor options generated by SCons we can avoid
hardcoding flags and recomputing libconfig flags.