### PR TITLE
update site_scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -48,8 +48,6 @@ def construct():
             TARGET_FRAMEWORKS=TARGET_FRAMEWORKS[target_arch],
             tools=['default', 'textfile', 'fscomp', 'scons_compilation_db'])
         fsenv.consider_environment_variables(arch_env)
-        if target_arch == "darwin":
-            arch_env.AppendENVPath("PATH", "/opt/local/bin")
         build_dir = os.path.join(
             fsenv.STAGE,
             target_arch,


### PR DESCRIPTION
New version of site_scons adds support for FSPKG_CONFIG_PATH and takes into
account Macports and Homebrew paths, so there's no need to add it in SConstruct
anymore