### PR TITLE
Fix build with OpenSSL 3

### DIFF
--- a/src/tls_openssl.c
+++ b/src/tls_openssl.c
@@ -30,7 +30,9 @@ static void openssl_initialize(void)
         return;
     initialized = true;
     SSL_load_error_strings();
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
     ERR_load_BIO_strings();
+#endif
     OPENSSL_add_all_algorithms_noconf();
     SSL_library_init();
 }


### PR DESCRIPTION
src/tls_openssl.c:33:5: error: 'ERR_load_BIO_strings' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]